### PR TITLE
Correspond to be able to use the wildcard to whitelist of host

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@
 var http       = require('http')
   , net        = require('net')
   , url        = require('url')
-  , util       = require('util')
   , whitehosts = require('./whitelist.json')
   , whitelist  = (require('./lib/whitelist'))(whitehosts);
 

--- a/index.js
+++ b/index.js
@@ -8,10 +8,12 @@
  * Otherwise, this server relays HTTP packets to internal git server.
  *   i.e. client <-HTTP-> this proxy <-HTTP-> internal git server.
  */
-var http      = require('http')
-  , net       = require('net')
-  , url       = require('url')
-  , whitelist = require('./whitelist.json');
+var http       = require('http')
+  , net        = require('net')
+  , url        = require('url')
+  , util       = require('util')
+  , whitehosts = require('./whitelist.json')
+  , whitelist  = (require('./lib/whitelist'))(whitehosts);
 
 process.on('uncaughtException', function(err) {
   printError(err);
@@ -47,7 +49,7 @@ server.on('connect', function(req, socket, head) {
 
   var dest = url.parse('https://' + req.url);
   var targetHost, targetPort, isWhite;
-  if (whitelist.indexOf(dest.hostname) === -1) {
+  if (!whitelist.isWhite(dest.hostname)) {
     targetHost = dest.hostname;
     targetPort = dest.port || 443;
     isWhite    = false;

--- a/lib/whitelist.js
+++ b/lib/whitelist.js
@@ -4,7 +4,6 @@ var util = require('util');
 
 function WhiteList(list) {
   this.list = util.isArray(list) ? list : [];
-  this.length = this.list.length;
 }
 
 WhiteList.prototype.isWhite = function(host) {

--- a/lib/whitelist.js
+++ b/lib/whitelist.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var util = require('util');
+
+function WhiteList(list) {
+  this.list = util.isArray(list) ? list : [];
+  this.length = this.list.length;
+}
+
+WhiteList.prototype.isWhite = function(host) {
+
+  function match(text, test) {
+    var regexp = new RegExp('^' + text.replace('.', '\\.').replace('*', '.+') + '$');
+    return regexp.test(test);
+  }
+
+  if (!this.list.length || typeof host != 'string') {
+    return false;
+  }
+
+  for (var i = 0; i < this.list.length; i++) {
+    var whiteHost = this.list[i];
+
+    if (typeof whiteHost != 'string') {
+      continue;
+    }
+
+    if (match(whiteHost, host)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+module.exports = function(list) {
+  return new WhiteList(list);
+}

--- a/lib/whitelist.js
+++ b/lib/whitelist.js
@@ -18,19 +18,12 @@ WhiteList.prototype.isWhite = function(host) {
     return false;
   }
 
-  for (var i = 0; i < this.list.length; i++) {
-    var whiteHost = this.list[i];
-
+  return this.list.some(function (whiteHost) {
     if (typeof whiteHost != 'string') {
-      continue;
+      return false;
     }
-
-    if (match(whiteHost, host)) {
-      return true;
-    }
-  }
-
-  return false;
+    return match(whiteHost, host);
+  })
 }
 
 module.exports = function(list) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "bin": "./bin/connect-proxy",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -21,5 +21,9 @@
   "bugs": {
     "url": "https://github.com/fujixerox/connect-proxy/issues"
   },
-  "homepage": "https://github.com/fujixerox/connect-proxy"
+  "homepage": "https://github.com/fujixerox/connect-proxy",
+  "devDependencies": {
+    "mocha": "^2.2.1",
+    "should": "^5.2.0"
+  }
 }

--- a/test/whitelist.js
+++ b/test/whitelist.js
@@ -6,19 +6,6 @@ describe('whitelist', function() {
   var hosts = [ 'github.com', 'bitbucket.com', '*.amazonaws.com' ];
   var whitelist = WhiteList(hosts);
 
-  describe('#init', function() {
-
-    it('should return 0 when the white list is initialized with not array', function() {
-      var emptyList = WhiteList({});
-      emptyList.length.should.be.empty
-    })
-
-    it('should return ' + hosts.length + ' when the white list is initialized with ' + hosts, function() {
-      whitelist.length.should.equal(hosts.length);
-    })
-
-  })
-
   describe('#isWhite', function() {
 
     it('should return false when the white list is initialized with empty array', function() {

--- a/test/whitelist.js
+++ b/test/whitelist.js
@@ -1,0 +1,61 @@
+var WhiteList = require('../lib/whitelist')
+  , should    = require('should');
+
+describe('whitelist', function() {
+
+  var hosts = [ 'github.com', 'bitbucket.com', '*.amazonaws.com' ];
+  var whitelist = WhiteList(hosts);
+
+  describe('#init', function() {
+
+    it('should return 0 when the white list is initialized with not array', function() {
+      var emptyList = WhiteList({});
+      emptyList.length.should.be.empty
+    })
+
+    it('should return ' + hosts.length + ' when the white list is initialized with ' + hosts, function() {
+      whitelist.length.should.equal(hosts.length);
+    })
+
+  })
+
+  describe('#isWhite', function() {
+
+    it('should return false when the white list is initialized with empty array', function() {
+      var emptyList = WhiteList([]);
+      emptyList.isWhite('test').should.be.false;
+    })
+
+    var tests = [
+    [ { test: 'test' }, false ],
+    [ [ 'test' ], false ],
+    [ 1, false ],
+    [ 1.0, false ],
+    [ 'test', false ],
+    [ 'com', false ],
+    [ 'github.com', true  ],
+    [ 'api.github.com', false ],
+    [ 'bitbucket.com', true  ],
+    [ 'api.bitbucket.com', false ],
+    [ 'amazon.com', false ],
+    [ 'aws.amazon.com', false ],
+    [ 'compute.amazonaws.com', true ],
+    [ 'ap-northeast-1.compute.amazonaws.com', true ],
+    [ 'ec2-127-0-0-1.ap-northeast-1.compute.amazonaws.com', true ]
+    ];
+
+    tests.forEach(function (test) {
+      it('should return ' + test[1] + ' when query is ' + test[0], function() {
+        whitelist.isWhite(test[0]).should.equal(test[1]);
+      })
+    })
+
+    tests.slice(4).forEach(function (test) {
+      it('should return true when the white list contains wildcard and query is ' + test[0], function() {
+        var wildcard = WhiteList([ '*' ]);
+        wildcard.isWhite(test[0]).should.be.true
+      })
+    })
+
+  })
+})

--- a/test/whitelist.js
+++ b/test/whitelist.js
@@ -37,7 +37,9 @@ describe('whitelist', function() {
       })
     })
 
-    tests.slice(4).forEach(function (test) {
+    tests.filter(function (test) {
+      return typeof test[0] === 'string';
+    }).forEach(function (test) {
       it('should return true when the white list contains wildcard and query is ' + test[0], function() {
         var wildcard = WhiteList([ '*' ]);
         wildcard.isWhite(test[0]).should.be.true

--- a/whitelist.json
+++ b/whitelist.json
@@ -1,1 +1,1 @@
-[ 'example.com' ]
+[ "example.com", "*.sample.com" ]


### PR DESCRIPTION
@stoshiya さん

connect-proxyに設定するwhitelistにwildcardを使えるようにしました．レビューをお願いします．
awsでインスタンスに自動で振り当てられるPublic DNS Nameが`*.amazonaws.com`という形式なため，それらにアクセスできるようにすることが目的です．